### PR TITLE
Blocking pool

### DIFF
--- a/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/Freeling.java
+++ b/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/Freeling.java
@@ -20,13 +20,11 @@ package io.insideout.stanbol.enhancer.nlp.freeling;
 import io.insideout.stanbol.enhancer.nlp.freeling.impl.AnalyzerFactory;
 import io.insideout.stanbol.enhancer.nlp.freeling.impl.LangIdFactory;
 import io.insideout.stanbol.enhancer.nlp.freeling.pool.ResourcePool;
-import io.insideout.stanbol.enhancer.nlp.freeling.pool.ResourcePool.ResourceFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -205,7 +203,7 @@ public class Freeling {
                context.put(AnalyzerFactory.PROPERTY_CONFIG_FILE, supported.getValue());
                log.debug(" ... create ResourcePool for {}",context);
                analyzerPools.put(supported.getKey(), new ResourcePool<Analyzer>(
-                       poolSize,minQueueSize, analyzerFactory, context));
+                       poolSize, analyzerFactory, context));
            }
        }
        if(langIdConfigFile == null){
@@ -219,7 +217,7 @@ public class Freeling {
                freelingLibPath, langIdConfigFile, locale, freelingInitThreadPool);
            //Finally init the language identifier resource pool
            langIdPool = new ResourcePool<LanguageIdentifier>(
-                   poolSize, minQueueSize,langIdFactory, null);
+                   poolSize, langIdFactory, null);
        }
     }
     /**

--- a/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/AnalyzerFactory.java
+++ b/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/AnalyzerFactory.java
@@ -23,9 +23,7 @@ import java.io.File;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.stanbol.enhancer.nlp.model.AnalysedText;
@@ -133,7 +131,7 @@ public class AnalyzerFactory implements ResourceFactory<AnalyzerImpl> {
     }
     
     @Override
-    public Future<AnalyzerImpl> createResource(Map<String,Object> context) {
+    public AnalyzerImpl createResource(Map<String,Object> context) {
         final String language = (String)context.get(PROPERTY_LANGUAGE);
         if(language == null){
             throw new IllegalArgumentException("The property '"+PROPERTY_LANGUAGE 
@@ -147,7 +145,11 @@ public class AnalyzerFactory implements ResourceFactory<AnalyzerImpl> {
         }
         log.info("Request to create Analyzer for language {}",language);
         final long request = System.currentTimeMillis();
-        return executorService.submit(new Callable<AnalyzerImpl>() {
+        AnalyzerImpl resource = createAnalyzer(configFile, language);
+        long created = System.currentTimeMillis();
+        log.info("  ... create in {}ms",created-request);
+        return resource;
+        /*return executorService.submit(new Callable<AnalyzerImpl>() {
 
             @Override
             public AnalyzerImpl call() throws Exception {
@@ -162,7 +164,7 @@ public class AnalyzerFactory implements ResourceFactory<AnalyzerImpl> {
                 }
             }
             
-        });
+        });*/
     }
     
     @Override

--- a/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/LangIdFactory.java
+++ b/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/LangIdFactory.java
@@ -19,9 +19,7 @@ package io.insideout.stanbol.enhancer.nlp.freeling.impl;
 import io.insideout.stanbol.enhancer.nlp.freeling.pool.ResourcePool.ResourceFactory;
 
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,10 +59,14 @@ public class LangIdFactory implements ResourceFactory<LanguageIdentifierImpl> {
     }
     
     @Override
-    public Future<LanguageIdentifierImpl> createResource(Map<String,Object> context) {
+    public LanguageIdentifierImpl createResource(Map<String,Object> context) {
         log.info("Request to create Language Identification Resource");
         final long request = System.currentTimeMillis();
-        return executorService.submit(new Callable<LanguageIdentifierImpl>() {
+        LanguageIdentifierImpl resource = new LanguageIdentifierImpl(configFile);
+        long created = System.currentTimeMillis();
+        log.info("  ... create in {}ms", created-request);
+        return resource;
+        /*return executorService.submit(new Callable<LanguageIdentifierImpl>() {
 
             @Override
             public LanguageIdentifierImpl call() throws Exception {
@@ -78,7 +80,7 @@ public class LangIdFactory implements ResourceFactory<LanguageIdentifierImpl> {
                 }
             }
             
-        });
+        });*/
     }
     
     @Override

--- a/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/LanguageIdentifierImpl.java
+++ b/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/impl/LanguageIdentifierImpl.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 import edu.upc.freeling.LangIdent;
 import edu.upc.freeling.PairDoubleString;
 import edu.upc.freeling.SWIGTYPE_p_std__setT_std__wstring_t;
-import edu.upc.freeling.Util;
 import edu.upc.freeling.VectorPairDoubleString;
 
 public class LanguageIdentifierImpl implements LanguageIdentifier {

--- a/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/pool/ResourcePool.java
+++ b/freeling-core/src/main/java/io/insideout/stanbol/enhancer/nlp/freeling/pool/ResourcePool.java
@@ -16,21 +16,14 @@
  */
 package io.insideout.stanbol.enhancer.nlp.freeling.pool;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * {@link ResourceFactory} is used to allow lazzy initialization of the
  * Resources in the pool
  * @author Rupert Westenthaler
+ * @author Rafa Haro <rharo@apache.org>
  *
  * @param <T> the type of the resource
  */
@@ -49,16 +43,12 @@ public class ResourcePool<T> {
     private final Logger log = LoggerFactory.getLogger(ResourcePool.class);
     
     public static final int DEFAULT_SIZE = 5;
-    public static final int DEFAULT_MIN_QUEUE_SIZE = 1;
 
     private int size;
-
-    private final Semaphore semaphore;
-    private final Queue<T> resources;
-    private final Queue<Future<? extends T>> creating; 
+    
+    private final BlockingQueue<T> resources; 
     private final ResourceFactory<? extends T> factory;
     private final Map<String,Object> context;
-    private final int minQueueSize;
 
     private boolean closed;
     
@@ -70,152 +60,60 @@ public class ResourcePool<T> {
      * @param context
      */
     @SuppressWarnings("unchecked")
-    public ResourcePool(int maxSize, int minQueueSize,  ResourceFactory<? extends T> factory, Map<String,Object> context) {
+    public ResourcePool(int size, ResourceFactory<? extends T> factory, Map<String,Object> context) {
         this.factory = factory;
-        this.size = maxSize <= 0 ? DEFAULT_SIZE : maxSize;
-        this.minQueueSize = minQueueSize < 0 ? DEFAULT_MIN_QUEUE_SIZE : 
-            minQueueSize > this.size ? this.size : minQueueSize;
+        this.size = size <= 0 ? DEFAULT_SIZE : size;
         this.context = context == null ? Collections.EMPTY_MAP : 
             Collections.unmodifiableMap(context);
-        this.semaphore = new Semaphore(this.size, true);
-        this.resources = new ConcurrentLinkedQueue<T>();
-        this.creating = new ConcurrentLinkedQueue<Future<? extends T>>();
-        if(this.minQueueSize > 0) {
-            for(int i=0; i <= (this.minQueueSize) && i < this.size; i++){
-                creating.add(factory.createResource(context));
+        this.resources = new LinkedBlockingQueue<T>();
+        log.info("Initializating Pool of Resources with size: " + this.size);
+        for(int i=0; i < this.size; i++){
+                resources.add(factory.createResource(context));
             }
-        }
     }
 
     public T getResource(long maxWaitMillis) throws PoolTimeoutException {
         if(closed){
             throw new IllegalStateException("This ResourcePool is already closed");
         }
-        // First, get permission to take or create a resource
+        
         try {
-            if(!semaphore.tryAcquire(maxWaitMillis, TimeUnit.MILLISECONDS)){
-                throw new PoolTimeoutException(maxWaitMillis, size ,
-                    semaphore.getQueueLength());
-            }
-        } catch (InterruptedException e) {
-            if(closed){
-                throw new IllegalStateException("This ResourcePool is already closed");
-            } else {
-                log.warn(" ... interrupted!",e);
-                return null;
-            }
-        }
-        T res = null;
-        Future<? extends T> future;
-        synchronized (resources) {
-            if(closed){
-                throw new IllegalStateException("This ResourcePool is already closed");
-            }
-            //check if creating resources are ready and add them to the queue
-            Iterator<Future<? extends T>> it = creating.iterator();
-            while(it.hasNext()){
-                Future<? extends T> f = it.next();
-                if(f.isDone()){
-                    it.remove();
-                    if(!f.isCancelled()){
-                        try {
-                            resources.add(f.get());
-                        } catch (InterruptedException e) {
-                            log.warn("Interupted while creating resource!", e);
-                        } catch (ExecutionException ee) {
-                            log.warn("Unable to create a Resoruce because of a "
-                                    + ee.getCause().getClass().getSimpleName()
-                                    + "while creating the Resource using "
-                                    + factory.getClass().getSimpleName() 
-                                    + " (message: "+ee.getCause().getMessage()
-                                    + ")!",ee);
-                        }
-                    } // else cancelled ... nothing to do
-                } // else still creating ... nothing to do
-            }
-            //now get the resources (if available) from the queue
-            res = resources.poll();
-            //if queue is to small create additional resources
-            if(resources.size() < minQueueSize || 
-                    res == null){ //in case minQueueSize == 0
-                creating.add(factory.createResource(context));
-            }
-            if(res == null){
-                future = creating.poll(); //creating can not be empty!
-            } else {
-                future = null;
-            }
-        }
-        if (res == null) { 
-            try { //we need to wait for the next resource to be created
-                return future.get();
-            } catch (InterruptedException e) {
-                // release this acquire as we do not deliver a resource
-                semaphore.release();
-                throw new IllegalStateException("Interupted",e);
-            } catch (ExecutionException ee) {
-                Throwable e = ee.getCause();
-                // release this acquire as we do not deliver a resource
-                semaphore.release();
-                throw new IllegalStateException("Unable to provide a Resoruce "
-                    + "because of a "+e.getClass().getSimpleName()
-                    + "while creating the Resource using "+ factory.getClass().getSimpleName()
-                    + " (message: "+e.getMessage()+")!",e);
-            } catch (RuntimeException e) { //should not happen
-                //so note this in the logs
-                log.warn("Unexpected "+e.getClass().getSimpleName()+"!");
-                semaphore.release(); //make sure we release the acquire
-                throw e; //re throw
-            }
-        } else { //return the resource polled from the queue
-            return res;
-        } //else  still enough resources in the queue
-    }
+			return resources.take();
+		} catch (InterruptedException e) {
+			throw new IllegalStateException("Interupted",e);
+		}
+     }
 
     public void returnResource(T res) {
-        try {
-            synchronized (resources) {
-                if(closed){
-                    factory.closeResource(res, context);
-                } else {
-                    resources.add(res); //return to the queue
-                }
-            }
-        } finally {
-           semaphore.release(); // and release the semaphore
-       }
+    	if(closed){
+    		factory.closeResource(res, context);
+    	} else {
+    		try {
+				resources.put(res);
+			} catch (InterruptedException e) {
+				throw new IllegalStateException("Interupted",e);
+			} //return to the queue
+    	}
     }
     /**
      * Closes this resource pool
      */
-    public void close() {
-        this.closed = true;
-        List<Future<? extends T>> toClose = new ArrayList<Future<? extends T>>();
-        synchronized (resources) {
-            for(Future<? extends T> f : creating){
-                if(f.isDone()){
-                    toClose.add(0, f); //add in the front
-                }
-                if(!f.cancel(false)){
-                    toClose.add(f); //add to the end (as we might need to wait for those)
-                } //cancelled before creation started - no need to close
-                
-            }
-            creating.clear();
-            for(T resource : resources){
-                factory.closeResource(resource, context);
-            }
-            resources.clear();
-        }
-        //now close the resources
-        for(Future<? extends T> f : toClose){
-            try {
-                factory.closeResource(f.get(), context);
-            } catch (InterruptedException e) {
-                log.warn("Interupted while closing resource ",e);
-            } catch (ExecutionException e) {
-                log.warn("Unable to close resource ",e);
-            }
+    public synchronized void close() {
+        if (!closed){    	
+        	this.closed = true;
+        	int counter = 0;
+        	while(counter != this.size){
+        		T resource = null;
+        		try {
+					resource = resources.take();
+				} catch (InterruptedException e) {
+					throw new IllegalStateException("Interupted",e);
+				}
+        		counter++;
+        		factory.closeResource(resource, context);
+        	}
+        	
+        	resources.clear();
         }
     }
     /**
@@ -238,7 +136,7 @@ public class ResourcePool<T> {
          * @throws IllegalArgumentException if the context is missing an
          * required information
          */
-        Future<T> createResource(Map<String,Object> context);
+        T createResource(Map<String,Object> context);
 
         /**
          * Request the Factory to close this resource. This allows the factory

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 		<dependencies>
       <dependency>
         <groupId>edu.upc.freeling</groupId>
-        <artifactId>edu.upc.freeling</artifactId>
-        <version>3.0</version>
+        <artifactId>freeling</artifactId>
+        <version>3.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.stanbol</groupId>


### PR DESCRIPTION
Current Resources' Pool creates new Resources objects when the Queue is empty. Those objects, once they have been used, are returned back to the Queue. If the server is being stressed by a huge number of concurrent requests (for example from a Hadoop cluster), the Resource Pool creates almost one new Resource for each request because the queue is empty for each new request. That is causing a huge memory usage because of new resource objects being created and not being never freed. Eventually, the SO kill the process because of the huge memory usage.

The solution involves the implementation of the Resource Pool with BlockingQueues of fixed sizes. When a new resource is needed, if the resource pool is empty, the thread will be waiting until one of the initialized resources is returned back to the queue.  
